### PR TITLE
Fix Test::More requirement

### DIFF
--- a/Meta
+++ b/Meta
@@ -27,6 +27,7 @@ requires:
 test:
   requires:
     Test::Exception: 0
+    Test::More: 0.98
 
 =zild:
   test-000: require


### PR DESCRIPTION
`done_testing()` appears only in `Test::More` > 0.88, hence we fail on earlier versions (e.g. as in perl-5.8.9). I've added a 0.98 req to be even [a bit more](https://metacpan.org/pod/Test::More#COMPATIBILITY) fail-resistant.

Sergey
